### PR TITLE
Fix/update string type conditions

### DIFF
--- a/sample.sia
+++ b/sample.sia
@@ -7,7 +7,7 @@ schema Person {
 }
 
 schema Address {
-  street?  string(encoding = "ascii") = "Default Street"
+  street?  string8(encoding = "utf64") = "Default Street"
   city     string8
   zip      int32
 }

--- a/src/generator/common/types.ts
+++ b/src/generator/common/types.ts
@@ -1,8 +1,6 @@
 import { SchemaDefinition } from "@/compiler/visitor.js";
 
 export const STRING_TYPES = [
-  "stringN",
-  "string",
   "string8",
   "string16",
   "string32",

--- a/src/generator/cpp/index.ts
+++ b/src/generator/cpp/index.ts
@@ -220,9 +220,11 @@ export class CPPGenerator implements CodeGenerator {
     }
 
     if (STRING_TYPES.includes(field.type as StringType)) {
-      const funcSuffix =
-        this.stringEncodingMap[(field.encoding as string) ?? "utf8"];
-      return `sia->Add${funcSuffix}(${accessExpr})`;
+      const suffix = field.encoding
+        ? this.stringEncodingMap[(field.encoding as string) ?? "utf8"]
+        : this.capitalizeFirstLetter(field.type);
+
+      return `sia->Add${suffix}(${accessExpr})`;
     }
     if (NUMBER_TYPES.includes(field.type as NumberType)) {
       const suffix = this.numbersEncodingMap[field.type];
@@ -263,9 +265,10 @@ export class CPPGenerator implements CodeGenerator {
     }
 
     if (STRING_TYPES.includes(field.type as StringType)) {
-      return assign(
-        `${siaVar}->Read${this.stringEncodingMap[(field.encoding as string) ?? "utf8"]}()`,
-      );
+      const suffix = field.encoding
+        ? this.stringEncodingMap[(field.encoding as string) ?? "utf8"]
+        : this.capitalizeFirstLetter(field.type);
+      return assign(`${siaVar}->Read${suffix}()`);
     }
     if (NUMBER_TYPES.includes(field.type as NumberType)) {
       return assign(`${siaVar}->Read${this.numbersEncodingMap[field.type]}()`);
@@ -351,6 +354,10 @@ export class CPPGenerator implements CodeGenerator {
     }
 
     return "";
+  }
+
+  private capitalizeFirstLetter(str: string): string {
+    return str.charAt(0).toUpperCase() + str.slice(1);
   }
 
   stringEncodingMap: Record<string, string> = {

--- a/src/generator/go/index.ts
+++ b/src/generator/go/index.ts
@@ -247,7 +247,10 @@ export class GoGenerator implements CodeGenerator {
     }
 
     if (STRING_TYPES.includes(fieldType as StringType)) {
-      const suffix = this.getStringEncodingSuffix(field.encoding as string);
+      const suffix = field.encoding
+        ? this.getStringEncodingSuffix(field.encoding as string)
+        : this.capitalizeFirstLetter(field.type);
+
       return `Add${suffix}(${ref})`;
     }
     if (this.BYTE_TYPE_MAP[fieldType]) {
@@ -266,7 +269,11 @@ export class GoGenerator implements CodeGenerator {
     const fieldType = field.type as FieldType;
 
     if (STRING_TYPES.includes(fieldType as StringType)) {
-      return `s.Read${this.getStringEncodingSuffix(field.encoding as string)}`;
+      const suffix = field.encoding
+        ? this.getStringEncodingSuffix(field.encoding as string)
+        : this.capitalizeFirstLetter(field.type);
+
+      return `s.Read${suffix}`;
     }
     if (this.BYTE_TYPE_MAP[fieldType]) {
       return `s.Read${this.BYTE_TYPE_MAP[fieldType]}`;
@@ -335,6 +342,10 @@ export class GoGenerator implements CodeGenerator {
       return `"${field.defaultValue}"`;
     }
     return `""`;
+  }
+
+  private capitalizeFirstLetter(str: string): string {
+    return str.charAt(0).toUpperCase() + str.slice(1);
   }
 
   STRING_ENCODING_MAP: Record<string, string> = {

--- a/src/generator/go/index.ts
+++ b/src/generator/go/index.ts
@@ -323,7 +323,9 @@ export class GoGenerator implements CodeGenerator {
 
     if (defaultVal == zero) return ref;
 
-    return `(func() ${fieldType} {
+    const goFieldType = this.fieldTypeToGoType(field as FieldDefinition);
+
+    return `(func() ${goFieldType} {
     if ${ref} == ${zero} {
       return ${defaultVal}
     }

--- a/src/generator/python/index.ts
+++ b/src/generator/python/index.ts
@@ -200,11 +200,10 @@ export class PyGenerator implements CodeGenerator {
   }
 
   private getSerializeFunctionName(field: FieldDefinition): string {
-    if (field.type === "string") {
-      const suffix = this.STRING_ENCODING_MAP[field.encoding as string];
-      if (!suffix) {
-        throw new Error(`Unknown string encoding: ${field.encoding}`);
-      }
+    if (STRING_TYPES.includes(field.type as StringType)) {
+      const suffix = field.encoding
+        ? this.STRING_ENCODING_MAP[field.encoding as string]
+        : field.type;
       return `sia.add_${suffix}`;
     }
 
@@ -237,11 +236,10 @@ export class PyGenerator implements CodeGenerator {
   }
 
   private getDeserializeFunctionName(field: FieldDefinition): string {
-    if (field.type === "string") {
-      const suffix = this.STRING_ENCODING_MAP[field.encoding as string];
-      if (!suffix) {
-        throw new Error(`Unknown string encoding: ${field.encoding}`);
-      }
+    if (STRING_TYPES.includes(field.type as StringType)) {
+      const suffix = field.encoding
+        ? this.STRING_ENCODING_MAP[field.encoding as string]
+        : field.type;
       return `sia.read_${suffix}`;
     }
 

--- a/src/generator/ts/index.ts
+++ b/src/generator/ts/index.ts
@@ -295,12 +295,21 @@ export class TSGenerator implements CodeGenerator {
     field: FieldDefinition,
     sia = "sia",
   ): string {
-    if (field.type === "string") {
+    if (STRING_TYPES.includes(field.type as StringType)) {
       if (field.encoding === "ascii") {
         return `${sia}.addAscii`;
+      } else {
+        switch (field.type) {
+          case "string8":
+            return `${sia}.addString8`;
+          case "string16":
+            return `${sia}.addString16`;
+          case "string32":
+            return `${sia}.addString32`;
+          case "string64":
+            return `${sia}.addString64`;
+        }
       }
-
-      throw new Error(`Unknown encoding: ${field.encoding}`);
     }
 
     if (BYTE_TYPES.includes(field.type as ByteType)) {
@@ -350,12 +359,21 @@ export class TSGenerator implements CodeGenerator {
     field: FieldDefinition,
     sia = "sia",
   ): string {
-    if (field.type === "string") {
+    if (STRING_TYPES.includes(field.type as StringType)) {
       if (field.encoding === "ascii") {
         return `${sia}.readAscii`;
+      } else {
+        switch (field.type) {
+          case "string8":
+            return `${sia}.readString8`;
+          case "string16":
+            return `${sia}.readString16`;
+          case "string32":
+            return `${sia}.readString32`;
+          case "string64":
+            return `${sia}.readString64`;
+        }
       }
-
-      throw new Error(`Unknown encoding: ${field.encoding}`);
     }
 
     if (BYTE_TYPES.includes(field.type as ByteType)) {

--- a/tests/expected-outputs/py/sample.py.expected
+++ b/tests/expected-outputs/py/sample.py.expected
@@ -53,7 +53,7 @@ class SampleAddress():
         self.zip = zip
 
     def encode(self, sia: Sia) -> Sia:
-        sia.add_string8(self.street)
+        sia.add_string8(self.street)  # ascii
         sia.add_string8(self.city)
         sia.add_int32(self.zip)
         return sia

--- a/tests/expected-outputs/ts/sample.ts.expected
+++ b/tests/expected-outputs/ts/sample.ts.expected
@@ -14,7 +14,7 @@ export interface Sample {
 export function encodeSample(sia: Sia, sample: Sample): Sia {
   sia.addString8(sample.name);
   sia.addInt32(sample.age ?? 0);
-  sia.addArray8(sample.email ?? [], (s: Sia, v) => s.addString8(v));
+  sia.addArray8(sample.email ?? [], (s: Sia, v) => s.addAscii(v));
   sia.addArray8(sample.tags, (s: Sia, v) => s.addString8(v));
   sia.addByteArrayN(sample.test ?? new Uint8Array(0));
   sia.addByteArray64(sample.test64);
@@ -26,7 +26,7 @@ export function decodeSample(sia: Sia): Sample {
   return {
     name: sia.readString8(),
     age: sia.readInt32(),
-    email: sia.readArray8((s: Sia) => s.readString8()),
+    email: sia.readArray8((s: Sia) => s.readAscii()),
     tags: sia.readArray8((s: Sia) => s.readString8()),
     test: sia.readByteArrayN(32),
     test64: sia.readByteArray64(),

--- a/tests/sample-mock.ts
+++ b/tests/sample-mock.ts
@@ -42,7 +42,7 @@ export const sampleSiaDefinition: Definition[] = [
     fields: [
       {
         name: "street",
-        type: "string",
+        type: "string8",
         encoding: "ascii",
         optional: true,
         isArray: false,


### PR DESCRIPTION
## Context

This fixes and closes issue #14 
And fixes the issue that didn't allow strings without specific encoding

### This led to:

- Allowing weird string types `stringN` and not allowing non-ASCII types (in ts only)
- Not allowing correct string types that doesn't have encoding specified

## Proposed solution

added a check for existence of encoding and prevented error being threw

## Tests

- All generators are tested to return error on `string` and `stringN`
- All generators give the correct output(with string without encodings)

## Notes

- This means users can no longer use `string` as a type
- This means if user specified string32(encoding= "utf64") results in `AddString64` and `ReadString64` (ignroing string type)